### PR TITLE
Update plugin.yml

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,6 +4,7 @@ version: ${project.version}
 api-version: 1.13
 loadbefore: [level, Ultimenu, UltiTools]
 softdepend: [Vault, PlaceholderAPI]
+load: STARTUP
 
 commands:
   money:


### PR DESCRIPTION
尽量确保在其他依赖Vault经济的插件启用之前启用，以免其他插件获取不到。
![QQ截图20211128175044](https://user-images.githubusercontent.com/26001944/143763407-752785e8-87ab-4c29-a8d3-9f67990032f9.png)
